### PR TITLE
Allow editing the profile display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Editable display name on profiles (capitalization and custom titles), stored in the existing on-chain `Bio.name` field
 - `CLAUDE.md` - AI agent instructions and project documentation
 - `AGENTS.md` - Symlink to CLAUDE.md for alternative agent systems
 - `SCRATCHPAD.md` - Agent process tracking file
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Raised TypeScript dependency floors for patched Next.js 16.3.x and react-router-dom 7.18.x
+- Added `typescript-eslint` so `pnpm lint` can load `eslint.config.mjs`
 
 ### Deprecated
 - None

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -4,6 +4,30 @@ This file tracks the progress of AI agent work on this project.
 
 ---
 
+## Session: 2026-08-25 (display name)
+
+### Objective
+Allow editing the profile title/name instead of always using the Aptos Name.
+
+### Tasks
+- [x] Confirm on-chain `Bio.name` already stores a display name
+- [x] Add display-name helpers and unit tests
+- [x] Add editor input; save custom name via `create` / `set_bio`
+- [x] Show custom name on public profile, metadata, and search
+- [ ] Lint, format, build, and verify UI
+
+### Notes
+- No Move contract change: `set_bio` / `create` already take `name`
+- Public heading uses on-chain name; ANS handle is shown underneath when it differs
+- Blank editor field falls back to the Aptos name when saving
+
+### Progress Log
+1. Issue #36: main name was ANS-only (e.g. no capitalization)
+2. Frontend always wrote `ansName` into `Bio.name` and rendered ANS in the H1
+3. Added `src/lib/displayName.ts` helpers and `node:test` coverage
+
+---
+
 ## Session: 2026-08-25
 
 ### Objective

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -14,7 +14,7 @@ Allow editing the profile title/name instead of always using the Aptos Name.
 - [x] Add display-name helpers and unit tests
 - [x] Add editor input; save custom name via `create` / `set_bio`
 - [x] Show custom name on public profile, metadata, and search
-- [ ] Lint, format, build, and verify UI
+- [x] Lint, format, build, and verify UI
 
 ### Notes
 - No Move contract change: `set_bio` / `create` already take `name`
@@ -24,7 +24,9 @@ Allow editing the profile title/name instead of always using the Aptos Name.
 ### Progress Log
 1. Issue #36: main name was ANS-only (e.g. no capitalization)
 2. Frontend always wrote `ansName` into `Bio.name` and rendered ANS in the H1
-3. Added `src/lib/displayName.ts` helpers and `node:test` coverage
+4. `pnpm lint` / `pnpm test` (12 tests) / `pnpm build` passed
+5. Production server: `/` connect gate, `/greg` still renders on-chain name `greg` (no extra handle when it matches ANS), unknown names 404
+6. Opened PR https://github.com/aptos-labs/apt-id/pull/61
 
 ---
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -13,6 +13,7 @@
     "start": "next start",
     "deploy": "vercel",
     "lint": "eslint src --max-warnings=0",
+    "test": "node --experimental-strip-types --experimental-default-type=module --test src/lib/*.test.ts",
     "_fmt": "prettier 'src/**/*.ts'",
     "fmt": "npm run _fmt -- --write"
   },
@@ -63,7 +64,8 @@
     "postcss": "^8.5.6",
     "prettier": "^3.7.4",
     "tree-kill": "1.2.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.68.0"
   },
   "pnpm": {
     "overrides": {

--- a/typescript/src/app/[name]/ProfileClient.tsx
+++ b/typescript/src/app/[name]/ProfileClient.tsx
@@ -34,10 +34,7 @@ export default function ProfileClient({ profile: initialProfile }: { profile: Pr
 
     if (loading) {
       fetchLatestProfile();
-    } else {
-      setLoading(false);
     }
-
   }, [profile.owner, profile, loading]);
 
   if (loading) {

--- a/typescript/src/app/[name]/page.tsx
+++ b/typescript/src/app/[name]/page.tsx
@@ -4,6 +4,7 @@ import { client } from "@/constants.ts";
 import { redirect } from "next/navigation";
 import NotFound from "@/app/not-found.tsx";
 import { getBio, getLinks } from "@/app/api/util.ts";
+import { getDisplayName } from "@/lib/displayName.ts";
 
 type Props = {
   params: Promise<{
@@ -28,8 +29,9 @@ export async function generateMetadata({ params }: Props, parent: ResolvingMetad
     const bio = await getBio(address.toString());
 
     if (bio) {
-      const title = `${name}'s Profile | Apt ID`;
-      const description = bio?.bio || `Check out ${name}'s profile on Apt ID`;
+      const displayName = getDisplayName({ name: bio.name, ansName: name });
+      const title = `${displayName}'s Profile | Apt ID`;
+      const description = bio?.bio || `Check out ${displayName}'s profile on Apt ID`;
       const imageUrl = bio?.avatar_url || `${baseUrl}/favicon.ico`;
 
       return {
@@ -45,7 +47,7 @@ export async function generateMetadata({ params }: Props, parent: ResolvingMetad
           description,
           images: [{
             url: imageUrl,
-            alt: `${name}'s profile picture`,
+            alt: `${displayName}'s profile picture`,
           }],
         },
       };

--- a/typescript/src/app/page.tsx
+++ b/typescript/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
   const router = useRouter();
   const { ansName, loading: ansLoading } = useAptosName();
   const [profile, setProfile] = useState<Profile | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -62,9 +62,6 @@ export default function Home() {
     if (connected && account?.address) {
       fetchProfile().then(() => {
       });
-    } else {
-      setLoaded(true);
-      setLoading(false);
     }
   }, [connected, account?.address, ansName, loaded]);
 
@@ -109,8 +106,13 @@ export default function Home() {
     return (
       <div className="flex flex-col gap-6">
         <h1 className="text-3xl font-bold text-white text-center">Edit Your Profile</h1>
-        <ProfileEditor ansName={ansName} profile={profile || undefined} onViewProfile={handleViewProfile}
-                       loading={loading || ansLoading} />
+        <ProfileEditor
+          key={profile ? profile.owner : `new-${ansName}`}
+          ansName={ansName}
+          profile={profile || undefined}
+          onViewProfile={handleViewProfile}
+          loading={loading || ansLoading}
+        />
       </div>
     );
   };

--- a/typescript/src/components/ProfileEditor.tsx
+++ b/typescript/src/components/ProfileEditor.tsx
@@ -1,11 +1,17 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Profile, ProfileLink } from '@/types';
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { Link as LinkIcon } from 'lucide-react';
 import {CONTRACT_ADDRESS} from "@/constants.ts";
-import Image from "next/image"; // Add LinkIcon
+import Image from "next/image";
+import {
+  DISPLAY_NAME_MAX_LENGTH,
+  formatAnsHandle,
+  resolveNameToSave,
+  stripAptSuffix,
+} from "@/lib/displayName.ts";
 
 interface ProfileEditorProps {
   ansName: string;
@@ -16,21 +22,13 @@ interface ProfileEditorProps {
 
 export function ProfileEditor({ ansName, profile, onViewProfile, loading = false }: ProfileEditorProps) {
   const { account, signAndSubmitTransaction } = useWallet();
-  const [bio, setBio] = useState<string>('');
-  const [avatar, setAvatar] = useState<string>('');
-  const [links, setLinks] = useState<ProfileLink[]>([]);
+  const fallbackName = stripAptSuffix(ansName);
+  const [displayName, setDisplayName] = useState<string>(profile?.name?.trim() || fallbackName);
+  const [bio, setBio] = useState<string>(profile?.description || '');
+  const [avatar, setAvatar] = useState<string>(profile?.profilePicture || '');
+  const [links, setLinks] = useState<ProfileLink[]>(profile?.links || []);
   const [saving, setSaving] = useState(false);
   const [editingLinkId, setEditingLinkId] = useState<string | null>(null);
-
-  // Initialize state with profile data when it becomes available
-  useEffect(() => {
-    console.log('Profile data received:', profile);
-    if (profile) {
-      setBio(profile.description || '');
-      setAvatar(profile.profilePicture || '');
-      setLinks(profile.links || []);
-    }
-  }, [profile]);
 
   const handleAddLink = () => {
     const newLink: ProfileLink = {
@@ -58,6 +56,8 @@ export function ProfileEditor({ ansName, profile, onViewProfile, loading = false
     setSaving(true);
 
     try {
+      const nameToSave = resolveNameToSave(displayName, ansName);
+
       // Check if profile exists using view function
       const response = await fetch(`/api/profile/exists?address=${account.address}`);
       let profileExists = false;
@@ -74,7 +74,7 @@ export function ProfileEditor({ ansName, profile, onViewProfile, loading = false
             function: `${CONTRACT_ADDRESS}::profile::create`,
             typeArguments: [],
             functionArguments: [
-              ansName,              // name: String
+              nameToSave,           // name: String
               bio,                  // bio: String
               avatar,               // avatar_url: Option<String>
               undefined,            // avatar_nft: Option<Object<Token>> - always empty for now
@@ -90,7 +90,7 @@ export function ProfileEditor({ ansName, profile, onViewProfile, loading = false
             function: `${CONTRACT_ADDRESS}::profile::set_bio`,
             typeArguments: [],
             functionArguments: [
-              ansName,     // name: String
+              nameToSave,           // name: String
               bio,                  // bio: String
               avatar,               // avatar_url: Option<String>
               undefined             // avatar_nft: Option<Object<Token>> - always empty for now
@@ -150,6 +150,21 @@ export function ProfileEditor({ ansName, profile, onViewProfile, loading = false
         
         {/* Profile Info */}
         <div className="text-center w-full max-w-[400px] mx-auto">
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder={stripAptSuffix(ansName) || "Display name"}
+            maxLength={DISPLAY_NAME_MAX_LENGTH}
+            aria-label="Display name"
+            className="text-[20px] sm:text-[24px] font-semibold text-white bg-white/10
+                     text-center w-full focus:outline-none focus:ring-1
+                     focus:ring-white/20 rounded-lg px-4 py-2 mb-1
+                     backdrop-blur-sm placeholder:text-white/40"
+          />
+          <p className="text-[13px] sm:text-[14px] text-white/60 mb-3">
+            {formatAnsHandle(ansName)}
+          </p>
           <textarea
             value={bio}
             onChange={(e) => setBio(e.target.value)}

--- a/typescript/src/components/PublicProfile.tsx
+++ b/typescript/src/components/PublicProfile.tsx
@@ -10,6 +10,7 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import { TwitterIcon, GithubIcon, FacebookIcon, InstagramIcon, LinkedinIcon } from "lucide-react";
 import { DiscordLogoIcon, PaperPlaneIcon, ExternalLinkIcon, Share1Icon, CopyIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
+import { formatAnsHandle, getDisplayName, shouldShowAnsHandle } from "@/lib/displayName.ts";
 
 interface PublicProfileProps {
   profile: Profile;
@@ -20,8 +21,9 @@ export default function PublicProfile({ profile }: PublicProfileProps) {
   const [shareText, setShareText] = useState("Share profile");
   const { account } = useWallet();
   const router = useRouter();
-  // Extract the username from ANS name (remove .apt)
-  const username = profile.ansName?.replace('.apt', '') ?? "N/A";
+  const displayName = getDisplayName(profile);
+  const ansHandle = formatAnsHandle(profile.ansName);
+  const showAnsHandle = shouldShowAnsHandle(displayName, profile.ansName);
   
   // Check if the current user is the profile owner
   const isOwner = account?.address?.toString() === profile.owner;
@@ -46,7 +48,7 @@ export default function PublicProfile({ profile }: PublicProfileProps) {
     if (navigator.share) {
       try {
         await navigator.share({
-          title: `${username}'s Apt ID Profile`,
+          title: `${displayName}'s Apt ID Profile`,
           url: shareUrl,
         });
       } catch (err) {
@@ -153,7 +155,7 @@ export default function PublicProfile({ profile }: PublicProfileProps) {
                 <button className="relative w-[96px] h-[96px] mb-4 sm:w-[120px] sm:h-[120px] rounded-full overflow-hidden hover:opacity-90 transition-opacity">
                   <Image
                     src={resolvedImageUrl}
-                    alt={`${username}'s profile picture`}
+                    alt={`${displayName}'s profile picture`}
                     width={120}
                     height={120}
                     className="rounded-full object-cover border-2 border-white shadow-lg w-full h-full"
@@ -167,7 +169,7 @@ export default function PublicProfile({ profile }: PublicProfileProps) {
                     <div className="relative">
                       <Image
                         src={resolvedImageUrl}
-                        alt={`${username}'s profile picture`}
+                        alt={`${displayName}'s profile picture`}
                         width={500}
                         height={500}
                         className="rounded-lg object-contain max-h-[90vh]"
@@ -200,10 +202,13 @@ export default function PublicProfile({ profile }: PublicProfileProps) {
 
             {/* Profile Info */}
             <div className="text-center w-full max-w-[400px] mx-auto">
-              <h1 className="text-[20px] sm:text-[24px] font-semibold text-white mb-2">
-                {username}
+              <h1 className="text-[20px] sm:text-[24px] font-semibold text-white">
+                {displayName}
               </h1>
-              <div className="flex items-center justify-center gap-4 mb-4">
+              {showAnsHandle && (
+                <p className="text-[13px] sm:text-[14px] text-white/60 mt-1">{ansHandle}</p>
+              )}
+              <div className="flex items-center justify-center gap-4 mt-3 mb-4">
                 <Tooltip.Provider>
                   <Tooltip.Root>
                     <Tooltip.Trigger asChild>

--- a/typescript/src/components/TopBar.tsx
+++ b/typescript/src/components/TopBar.tsx
@@ -11,7 +11,8 @@ import { SearchIcon } from 'lucide-react';
 export function TopBar() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<{ 
-    name: string; 
+    name: string;
+    displayName?: string;
     exists: boolean;
     bio?: string;
     avatar?: string;
@@ -37,6 +38,7 @@ export function TopBar() {
           const bio = await bioResponse.json();
           setSearchResults([{
             name: cleanQuery,
+            displayName: bio.name || cleanQuery,
             exists: response.ok,
             bio: bio.bio || '',
             avatar: bio.avatar_url || '/favicon.ico'
@@ -126,14 +128,17 @@ export function TopBar() {
                         {result.avatar && (
                           <Image
                             src={result.avatar}
-                            alt={result.name}
+                            alt={result.displayName || result.name}
                             width={32}
                             height={32}
                             className="rounded-full"
                           />
                         )}
                         <div className="flex flex-col">
-                          <span>{result.name}</span>
+                          <span>{result.displayName || result.name}</span>
+                          {result.displayName && result.displayName !== result.name && (
+                            <span className="text-xs text-gray-400">{result.name}.apt</span>
+                          )}
                           {result.bio && (
                             <span className="text-sm text-gray-500 truncate max-w-[300px]">
                               {result.bio}

--- a/typescript/src/lib/displayName.test.ts
+++ b/typescript/src/lib/displayName.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DISPLAY_NAME_MAX_LENGTH,
+  formatAnsHandle,
+  getDisplayName,
+  resolveNameToSave,
+  shouldShowAnsHandle,
+  stripAptSuffix,
+} from "./displayName.ts";
+
+test("stripAptSuffix removes a trailing .apt suffix", () => {
+  assert.equal(stripAptSuffix("greg.apt"), "greg");
+  assert.equal(stripAptSuffix("greg.APT"), "greg");
+  assert.equal(stripAptSuffix("greg"), "greg");
+  assert.equal(stripAptSuffix(null), "");
+  assert.equal(stripAptSuffix(undefined), "");
+});
+
+test("formatAnsHandle always presents the ANS name with .apt", () => {
+  assert.equal(formatAnsHandle("greg"), "greg.apt");
+  assert.equal(formatAnsHandle("greg.apt"), "greg.apt");
+  assert.equal(formatAnsHandle(null), "");
+});
+
+test("getDisplayName prefers a custom on-chain name over the Aptos name", () => {
+  assert.equal(getDisplayName({ name: "Greg", title: "Ignored", ansName: "greg.apt" }), "Greg");
+});
+
+test("getDisplayName uses title when name is empty", () => {
+  assert.equal(getDisplayName({ name: "  ", title: "Greg Nazario", ansName: "greg" }), "Greg Nazario");
+});
+
+test("getDisplayName falls back to the Aptos name without .apt", () => {
+  assert.equal(getDisplayName({ name: "", title: "", ansName: "greg.apt" }), "greg");
+});
+
+test("getDisplayName returns N/A when nothing is available", () => {
+  assert.equal(getDisplayName({}), "N/A");
+});
+
+test("shouldShowAnsHandle is false when the display name matches the Aptos name", () => {
+  assert.equal(shouldShowAnsHandle("greg", "greg.apt"), false);
+  assert.equal(shouldShowAnsHandle("greg.apt", "greg"), false);
+});
+
+test("shouldShowAnsHandle is true when capitalization or the full title differs", () => {
+  assert.equal(shouldShowAnsHandle("Greg", "greg.apt"), true);
+  assert.equal(shouldShowAnsHandle("Greg Nazario", "greg"), true);
+});
+
+test("shouldShowAnsHandle is false when there is no Aptos name", () => {
+  assert.equal(shouldShowAnsHandle("Greg", null), false);
+});
+
+test("resolveNameToSave keeps a custom display name", () => {
+  assert.equal(resolveNameToSave("Greg", "greg.apt"), "Greg");
+});
+
+test("resolveNameToSave falls back to the Aptos name when the field is blank", () => {
+  assert.equal(resolveNameToSave("   ", "greg.apt"), "greg");
+  assert.equal(resolveNameToSave("", "greg"), "greg");
+});
+
+test("resolveNameToSave truncates names longer than the max length", () => {
+  const tooLong = "A".repeat(DISPLAY_NAME_MAX_LENGTH + 10);
+  assert.equal(resolveNameToSave(tooLong, "greg").length, DISPLAY_NAME_MAX_LENGTH);
+});

--- a/typescript/src/lib/displayName.ts
+++ b/typescript/src/lib/displayName.ts
@@ -1,0 +1,42 @@
+export const DISPLAY_NAME_MAX_LENGTH = 64;
+
+export function stripAptSuffix(ansName: string | null | undefined): string {
+  if (!ansName) {
+    return "";
+  }
+  return ansName.replace(/\.apt$/i, "").trim();
+}
+
+export function formatAnsHandle(ansName: string | null | undefined): string {
+  const handle = stripAptSuffix(ansName);
+  return handle ? `${handle}.apt` : "";
+}
+
+export function getDisplayName(profile: {
+  name?: string | null;
+  title?: string | null;
+  ansName?: string | null;
+}): string {
+  const custom = profile.name?.trim() || profile.title?.trim() || "";
+  if (custom) {
+    return custom;
+  }
+  return stripAptSuffix(profile.ansName) || "N/A";
+}
+
+export function shouldShowAnsHandle(displayName: string, ansName: string | null | undefined): boolean {
+  const handle = stripAptSuffix(ansName);
+  if (!handle) {
+    return false;
+  }
+  const normalizedDisplay = displayName.trim().replace(/\.apt$/i, "");
+  return normalizedDisplay !== handle;
+}
+
+export function resolveNameToSave(displayName: string, ansName: string): string {
+  const trimmed = displayName.trim().slice(0, DISPLAY_NAME_MAX_LENGTH);
+  if (trimmed) {
+    return trimmed;
+  }
+  return stripAptSuffix(ansName) || ansName;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #36

The public profile heading was always the Aptos Name (so capitalization and custom titles were impossible). The Move contract already stores a display name as `Bio.name`; the frontend just never let users edit it and never rendered it.

## What changed
- Profile editor has a display name field (defaults to the Aptos name, max 64 characters)
- Saving writes that value through the existing `create` / `set_bio` `name` argument
- Public profile, Open Graph title, and search results show the custom name
- The Aptos name (`name.apt`) is shown as a handle when it differs from the display name (for example `Greg` vs `greg.apt`)
- Blank names fall back to the Aptos name so existing profiles keep working

No contract upgrade is required.

## Test plan
- [x] `pnpm test` — 12/12 display-name helper tests
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `/` still shows the connect-wallet gate
- [x] `/greg` still renders the on-chain name `greg` (no extra ANS handle when it matches)
- [x] Unknown names still 404
- [ ] Saving a customized name (needs a connected wallet on mainnet)

[Unconnected home](https://cursor.com/agents/bc-a812b866-755e-4e6a-8e9e-3f77980b969b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome.png)
[Existing greg profile](https://cursor.com/agents/bc-a812b866-755e-4e6a-8e9e-3f77980b969b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fgreg-profile.png)
[Missing profile](https://cursor.com/agents/bc-a812b866-755e-4e6a-8e9e-3f77980b969b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmissing-profile.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a812b866-755e-4e6a-8e9e-3f77980b969b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a812b866-755e-4e6a-8e9e-3f77980b969b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

