### PR TITLE
Add primary social accounts to Apt ID profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
+- Primary social accounts on Apt ID profiles (X, Telegram, GitHub)
+  - Stored in the existing LinkTree using `__primary:` keys, with a `get_primary_socials` view and optional `set_primary_social` / `remove_primary_social` entry functions
+  - Profile editor fields and a public-profile icon row, parsed from existing links so it works before a contract upgrade
 - Editable display name on profiles (capitalization and custom titles), stored in the existing on-chain `Bio.name` field
 - `CLAUDE.md` - AI agent instructions and project documentation
 - `AGENTS.md` - Symlink to CLAUDE.md for alternative agent systems

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -19,6 +19,9 @@ Add prefix-based primary social accounts (X, Telegram, GitHub) per issue #51.
 - Primary socials use LinkTree keys prefixed with `__primary:`
 - Frontend filters those keys out of the regular links list
 - Contract view is additive; frontend works against the currently deployed module by parsing `view_links`
+- Rebased onto `main` (display-name #61 + dependency bumps). Combined UI: display name, ANS handle subtitle, primary-social icon row.
+- GitHub PR #62 had no review threads; prior hardening (host checks, single `create()`, `url` arg, no `loaded` fetch dep) kept through rebase.
+- After rebase: `pnpm lint`, `pnpm test` (21), `tsc --noEmit`, `pnpm build`, `aptos move test` (3), Vercel checks green.
 
 ---
 

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -4,6 +4,24 @@ This file tracks the progress of AI agent work on this project.
 
 ---
 
+## Session: 2026-08-25 (primary socials)
+
+### Objective
+Add prefix-based primary social accounts (X, Telegram, GitHub) per issue #51.
+
+### Tasks
+- [x] Add Move `get_primary_socials` view and convenience entry functions with unit tests
+- [x] Add TypeScript constants, parsing helpers, editor fields, and public icon row
+- [x] Parse primary socials from existing LinkTree data (no extra view call required)
+- [ ] Indexer: no schema change needed (links already stored in LinkTree)
+
+### Notes
+- Primary socials use LinkTree keys prefixed with `__primary:`
+- Frontend filters those keys out of the regular links list
+- Contract view is additive; frontend works against the currently deployed module by parsing `view_links`
+
+---
+
 ## Session: 2026-08-25 (display name)
 
 ### Objective

--- a/move/sources/profile.move
+++ b/move/sources/profile.move
@@ -5,7 +5,7 @@ module profile_address::profile {
 
     use std::option::{Self, Option};
     use std::signer;
-    use std::string::String;
+    use std::string::{Self, String};
     use aptos_std::simple_map::{Self, SimpleMap};
     use aptos_framework::event::emit;
     use aptos_framework::object::{Self, DeleteRef, ExtendRef, Object};
@@ -103,6 +103,9 @@ module profile_address::profile {
 
     /// Image URL and NFT can't both be given, only one or the other
     const E_IMAGE_AND_NFT: u64 = 4;
+
+    /// Prefix used to store primary social accounts in the LinkTree
+    const PRIMARY_SOCIAL_PREFIX: vector<u8> = b"__primary:";
 
     /// Creates an unordered profile
     ///
@@ -326,6 +329,20 @@ module profile_address::profile {
         });
     }
 
+    /// Set a primary social account (convenience wrapper around add_links)
+    public entry fun set_primary_social(
+        caller: &signer, platform: String, handle: String
+    ) acquires ProfileRef, LinkTree {
+        add_links(caller, vector[primary_social_key(platform)], vector[handle]);
+    }
+
+    /// Remove a primary social account (convenience wrapper around remove_links)
+    public entry fun remove_primary_social(
+        caller: &signer, platform: String
+    ) acquires ProfileRef, LinkTree {
+        remove_links(caller, vector[primary_social_key(platform)]);
+    }
+
     /// Delete the Profile and return the NFTs if any
     public entry fun delete(caller: &signer) acquires ProfileRef, Bio, LinkTree, Controller {
         let caller_address = signer::address_of(caller);
@@ -398,6 +415,34 @@ module profile_address::profile {
         }
     }
 
+    #[view]
+    /// Returns primary social accounts stored as LinkTree keys with the "__primary:" prefix
+    public fun get_primary_socials(owner: address): SimpleMap<String, String> acquires ProfileRef, LinkTree {
+        let maybe_profile_address = get_profile_address(owner);
+        if (maybe_profile_address.is_none()) {
+            return simple_map::new()
+        };
+
+        let profile_address = maybe_profile_address.destroy_some();
+        let link_tree = borrow_global<LinkTree>(profile_address);
+        let primary_socials = simple_map::new<String, String>();
+        let prefix = string::utf8(PRIMARY_SOCIAL_PREFIX);
+        let prefix_len = prefix.length();
+        let keys = link_tree.links.keys();
+
+        for (i in 0..keys.length()) {
+            let key = keys[i];
+            if (key.length() >= prefix_len && key.sub_string(0, prefix_len) == prefix) {
+                let platform = key.sub_string(prefix_len, key.length());
+                if (platform.length() > 0) {
+                    primary_socials.upsert(platform, link_tree.links.borrow(&key).url);
+                }
+            }
+        };
+
+        primary_socials
+    }
+
     /// Creates an untransferrable object
     fun create_object(owner_address: address): signer {
         let const_ref = object::create_object(owner_address);
@@ -414,6 +459,13 @@ module profile_address::profile {
 
         move_to(&object_signer, Controller { extend_ref, delete_ref });
         object_signer
+    }
+
+    /// Builds a LinkTree key for a primary social platform
+    fun primary_social_key(platform: String): String {
+        let key = string::utf8(PRIMARY_SOCIAL_PREFIX);
+        string::append(&mut key, platform);
+        key
     }
 
     /// Converts string links to Link type
@@ -448,5 +500,61 @@ module profile_address::profile {
                 object::delete(delete_ref)
             }
         }
+    }
+
+    #[test_only]
+    fun utf8(bytes: vector<u8>): String {
+        string::utf8(bytes)
+    }
+
+    #[test]
+    fun test_get_primary_socials_empty_without_profile() {
+        let socials = get_primary_socials(@0x123);
+        assert!(socials.length() == 0, 0);
+    }
+
+    #[test(user = @0x123)]
+    fun test_get_primary_socials_filters_prefixed_links(user: &signer) {
+        create(
+            user,
+            utf8(b"Alice"),
+            utf8(b"Hello"),
+            option::some(utf8(b"https://example.com/a.png")),
+            option::none<Object<Token>>(),
+            vector[utf8(b"Website"), utf8(b"__primary:x"), utf8(b"__primary:github")],
+            vector[
+                utf8(b"https://example.com"),
+                utf8(b"https://x.com/alice"),
+                utf8(b"https://github.com/alice")
+            ]
+        );
+
+        let socials = get_primary_socials(signer::address_of(user));
+        assert!(socials.length() == 2, 0);
+        assert!(*socials.borrow(&utf8(b"x")) == utf8(b"https://x.com/alice"), 1);
+        assert!(*socials.borrow(&utf8(b"github")) == utf8(b"https://github.com/alice"), 2);
+        assert!(!socials.contains_key(&utf8(b"Website")), 3);
+    }
+
+    #[test(user = @0x123)]
+    fun test_set_and_remove_primary_social(user: &signer) {
+        create(
+            user,
+            utf8(b"Alice"),
+            utf8(b"Hello"),
+            option::some(utf8(b"https://example.com/a.png")),
+            option::none<Object<Token>>(),
+            vector[],
+            vector[]
+        );
+
+        set_primary_social(user, utf8(b"telegram"), utf8(b"https://t.me/alice"));
+        let socials = get_primary_socials(signer::address_of(user));
+        assert!(socials.length() == 1, 0);
+        assert!(*socials.borrow(&utf8(b"telegram")) == utf8(b"https://t.me/alice"), 1);
+
+        remove_primary_social(user, utf8(b"telegram"));
+        let socials_after = get_primary_socials(signer::address_of(user));
+        assert!(socials_after.length() == 0, 2);
     }
 }

--- a/move/sources/profile.move
+++ b/move/sources/profile.move
@@ -329,11 +329,11 @@ module profile_address::profile {
         });
     }
 
-    /// Set a primary social account (convenience wrapper around add_links)
+    /// Set a primary social account. `url` is stored as the LinkTree value (full URL recommended).
     public entry fun set_primary_social(
-        caller: &signer, platform: String, handle: String
+        caller: &signer, platform: String, url: String
     ) acquires ProfileRef, LinkTree {
-        add_links(caller, vector[primary_social_key(platform)], vector[handle]);
+        add_links(caller, vector[primary_social_key(platform)], vector[url]);
     }
 
     /// Remove a primary social account (convenience wrapper around remove_links)

--- a/typescript/src/app/[name]/ProfileClient.tsx
+++ b/typescript/src/app/[name]/ProfileClient.tsx
@@ -4,38 +4,47 @@ import { useEffect, useState } from "react";
 import PublicProfile from "../../components/PublicProfile";
 import { Profile } from "@/types";
 import { fetchBioAndLinks } from "@/app/api/util.ts";
+import { splitProfileLinks } from "@/lib/primarySocials.ts";
 
 export default function ProfileClient({ profile: initialProfile }: { profile: Profile }) {
   const [loading, setLoading] = useState(true);
   const [profile, setProfile] = useState<Profile>(initialProfile);
 
   useEffect(() => {
+    let cancelled = false;
+
     const fetchLatestProfile = async () => {
       try {
-        const [bio, links] = await fetchBioAndLinks(profile.owner)
+        const [bio, links] = await fetchBioAndLinks(initialProfile.owner);
 
-        if (bio) {
-          // Update profile with latest data
-          setProfile({
-            ...profile,
-            name: bio.name,
-            profilePicture: bio.avatar_url || "", // TODO: Make a default
-            description: bio.bio,
-            title: bio.name,
-            links: links,
-          });
+        if (cancelled || !bio) {
+          return;
         }
+
+        const { regularLinks, primarySocials } = splitProfileLinks(Array.isArray(links) ? links : []);
+        setProfile({
+          ...initialProfile,
+          name: bio.name,
+          profilePicture: bio.avatar_url || "", // TODO: Make a default
+          description: bio.bio,
+          title: bio.name,
+          links: regularLinks,
+          primarySocials,
+        });
       } catch (error) {
         console.error("Error fetching latest profile:", error);
       } finally {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     };
 
-    if (loading) {
-      fetchLatestProfile();
-    }
-  }, [profile.owner, profile, loading]);
+    fetchLatestProfile();
+    return () => {
+      cancelled = true;
+    };
+  }, [initialProfile]);
 
   if (loading) {
     return (

--- a/typescript/src/app/[name]/page.tsx
+++ b/typescript/src/app/[name]/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import NotFound from "@/app/not-found.tsx";
 import { getBio, getLinks } from "@/app/api/util.ts";
 import { getDisplayName } from "@/lib/displayName.ts";
+import { splitProfileLinks } from "@/lib/primarySocials.ts";
 
 type Props = {
   params: Promise<{
@@ -98,6 +99,7 @@ export default async function ProfilePage(props: PageProps) {
     return <NotFound aptName={params.name} />;
   }
   const [bio, links] = await Promise.all([getBio(address).catch(() => undefined), getLinks(address).catch(() => [])]);
+  const { regularLinks, primarySocials } = splitProfileLinks(links ?? []);
 
   // Create a profile using the URL parameter as the ANS name
   const profile = {
@@ -107,7 +109,8 @@ export default async function ProfilePage(props: PageProps) {
     profilePicture: bio?.avatar_url ?? "",
     description: bio?.bio ?? "",
     title: bio?.name ?? "",
-    links: links ?? [],
+    links: regularLinks,
+    primarySocials,
   };
 
   if (!profile.owner || bio?.name === undefined) {

--- a/typescript/src/app/page.tsx
+++ b/typescript/src/app/page.tsx
@@ -16,7 +16,7 @@ export default function Home() {
   const router = useRouter();
   const { ansName, loading: ansLoading } = useAptosName();
   const [profile, setProfile] = useState<Profile | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!connected || !account?.address) {

--- a/typescript/src/app/page.tsx
+++ b/typescript/src/app/page.tsx
@@ -7,6 +7,7 @@ import { useAptosName } from "../hooks/useAptosName";
 import { ProfileEditor } from "../components/ProfileEditor";
 import { useEffect, useState } from "react";
 import { Profile } from "@/types";
+import { splitProfileLinks } from "@/lib/primarySocials.ts";
 import { fetchBioAndLinks } from "@/app/api/util.ts";
 import Link from "next/link";
 
@@ -16,30 +17,30 @@ export default function Home() {
   const { ansName, loading: ansLoading } = useAptosName();
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(false);
-  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    const fetchProfile = async () => {
-      if (!account?.address) {
-        setLoaded(false);
-        setLoading(false);
-        return;
-      }
+    if (!connected || !account?.address) {
+      return;
+    }
 
-      if (!loaded) {
-        setLoading(true);
-      }
+    let cancelled = false;
+
+    const fetchProfile = async () => {
+      setLoading(true);
       try {
         const [bio, links] = await fetchBioAndLinks(account.address.toString());
+        if (cancelled) {
+          return;
+        }
 
         if (bio?.error || !bio) {
           console.log("Bio fetch error:", bio.error);
           setProfile(null);
-          setLoading(false);
           return;
         }
 
-        // Create profile object
+        const { regularLinks, primarySocials } = splitProfileLinks(Array.isArray(links) ? links : []);
+
         const profileData: Profile = {
           owner: account.address.toString(),
           ansName: ansName,
@@ -47,23 +48,28 @@ export default function Home() {
           profilePicture: bio.avatar_url || "",
           description: bio.bio || "",
           title: bio.name || "",
-          links: Array.isArray(links) ? links : [],
+          links: regularLinks,
+          primarySocials,
         };
 
         setProfile(profileData);
       } catch (error) {
         console.error("Error fetching profile:", error);
-        setProfile(null);
+        if (!cancelled) {
+          setProfile(null);
+        }
       } finally {
-        setLoaded(true);
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     };
-    if (connected && account?.address) {
-      fetchProfile().then(() => {
-      });
-    }
-  }, [connected, account?.address, ansName, loaded]);
+
+    fetchProfile();
+    return () => {
+      cancelled = true;
+    };
+  }, [connected, account?.address, ansName]);
 
   const handleViewProfile = async () => {
     if (connected) {

--- a/typescript/src/components/PrimarySocialIcon.tsx
+++ b/typescript/src/components/PrimarySocialIcon.tsx
@@ -1,0 +1,15 @@
+import { GithubIcon, TwitterIcon } from "lucide-react";
+import { ExternalLinkIcon, PaperPlaneIcon } from "@radix-ui/react-icons";
+
+export function PrimarySocialIcon({ platform, className = "w-4 h-4" }: { platform: string; className?: string }) {
+  switch (platform) {
+    case "x":
+      return <TwitterIcon className={className} />;
+    case "telegram":
+      return <PaperPlaneIcon className={className} />;
+    case "github":
+      return <GithubIcon className={className} />;
+    default:
+      return <ExternalLinkIcon className={className} />;
+  }
+}

--- a/typescript/src/components/ProfileEditor.tsx
+++ b/typescript/src/components/ProfileEditor.tsx
@@ -4,14 +4,23 @@ import { useState } from 'react';
 import { Profile, ProfileLink } from '@/types';
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { Link as LinkIcon } from 'lucide-react';
-import {CONTRACT_ADDRESS} from "@/constants.ts";
+import { CONTRACT_ADDRESS } from "@/constants.ts";
 import Image from "next/image";
+import { PrimarySocialIcon } from "./PrimarySocialIcon";
 import {
   DISPLAY_NAME_MAX_LENGTH,
   formatAnsHandle,
   resolveNameToSave,
   stripAptSuffix,
 } from "@/lib/displayName.ts";
+import {
+  SUPPORTED_PRIMARY_SOCIALS,
+  buildPrimarySocialUpdates,
+  extractPrimarySocialHandle,
+  isPrimarySocialKey,
+  splitProfileLinks,
+  type PrimarySocialPlatform,
+} from "@/lib/primarySocials.ts";
 
 interface ProfileEditorProps {
   ansName: string;
@@ -20,15 +29,48 @@ interface ProfileEditorProps {
   loading?: boolean;
 }
 
+function editorStateFromProfile(profile: Profile | undefined, ansName: string) {
+  const split = splitProfileLinks(profile?.links || []);
+  const urls = { ...split.primarySocials, ...(profile?.primarySocials || {}) };
+  const handles: Record<string, string> = {};
+  (Object.keys(SUPPORTED_PRIMARY_SOCIALS) as PrimarySocialPlatform[]).forEach((platform) => {
+    handles[platform] = urls[platform] ? extractPrimarySocialHandle(platform, urls[platform]) : '';
+  });
+  Object.entries(urls).forEach(([platform, url]) => {
+    if (!(platform in handles)) {
+      handles[platform] = extractPrimarySocialHandle(platform, url);
+    }
+  });
+  return {
+    displayName: profile?.name?.trim() || stripAptSuffix(ansName),
+    bio: profile?.description || '',
+    avatar: profile?.profilePicture || '',
+    links: split.regularLinks,
+    handles,
+  };
+}
+
 export function ProfileEditor({ ansName, profile, onViewProfile, loading = false }: ProfileEditorProps) {
   const { account, signAndSubmitTransaction } = useWallet();
-  const fallbackName = stripAptSuffix(ansName);
-  const [displayName, setDisplayName] = useState<string>(profile?.name?.trim() || fallbackName);
-  const [bio, setBio] = useState<string>(profile?.description || '');
-  const [avatar, setAvatar] = useState<string>(profile?.profilePicture || '');
-  const [links, setLinks] = useState<ProfileLink[]>(profile?.links || []);
+  const initial = editorStateFromProfile(profile, ansName);
+  const [displayName, setDisplayName] = useState<string>(initial.displayName);
+  const [bio, setBio] = useState<string>(initial.bio);
+  const [avatar, setAvatar] = useState<string>(initial.avatar);
+  const [links, setLinks] = useState<ProfileLink[]>(initial.links);
+  const [primarySocials, setPrimarySocials] = useState<Record<string, string>>(initial.handles);
   const [saving, setSaving] = useState(false);
   const [editingLinkId, setEditingLinkId] = useState<string | null>(null);
+  const [profileSnapshot, setProfileSnapshot] = useState(profile);
+
+  if (profile !== profileSnapshot) {
+    const next = editorStateFromProfile(profile, ansName);
+    setProfileSnapshot(profile);
+    setDisplayName(next.displayName);
+    setBio(next.bio);
+    setAvatar(next.avatar);
+    setLinks(next.links);
+    setPrimarySocials(next.handles);
+  }
 
   const handleAddLink = () => {
     const newLink: ProfileLink = {
@@ -57,64 +99,26 @@ export function ProfileEditor({ ansName, profile, onViewProfile, loading = false
 
     try {
       const nameToSave = resolveNameToSave(displayName, ansName);
+      const regularLinks = links.filter((link) => !isPrimarySocialKey(link.title) && !isPrimarySocialKey(link.id));
+      const { toUpsert } = buildPrimarySocialUpdates(primarySocials);
+      const names = [...regularLinks.map((link) => link.title), ...toUpsert.names];
+      const urls = [...regularLinks.map((link) => link.url), ...toUpsert.urls];
 
-      // Check if profile exists using view function
-      const response = await fetch(`/api/profile/exists?address=${account.address}`);
-      let profileExists = false;
-
-      // TODO: Verify that the profile API is working, and remove this check or handle 404 properly elsewhere
-      if (response.status !== 404) {
-        profileExists = await response.json();
-      }
-
-      if (!profileExists) {
-        // Create profile if it doesn't exist
-        await signAndSubmitTransaction({
-          data: {
-            function: `${CONTRACT_ADDRESS}::profile::create`,
-            typeArguments: [],
-            functionArguments: [
-              nameToSave,           // name: String
-              bio,                  // bio: String
-              avatar,               // avatar_url: Option<String>
-              undefined,            // avatar_nft: Option<Object<Token>> - always empty for now
-              links.map(link => link.title),  // names: vector<String>
-              links.map(link => link.url),    // links: vector<String>
-            ],
-          },
-        });
-      } else {
-        // Update existing profile
-        await signAndSubmitTransaction({
-          data: {
-            function: `${CONTRACT_ADDRESS}::profile::set_bio`,
-            typeArguments: [],
-            functionArguments: [
-              nameToSave,           // name: String
-              bio,                  // bio: String
-              avatar,               // avatar_url: Option<String>
-              undefined             // avatar_nft: Option<Object<Token>> - always empty for now
-            ],
-          },
-        });
-
-        // Then save links
-        if (links.length > 0) {
-          const names = links.map(link => link.title);
-          const urls = links.map(link => link.url);
-
-          await signAndSubmitTransaction({
-            data: {
-              function: `${CONTRACT_ADDRESS}::profile::add_links`,
-              typeArguments: [],
-              functionArguments: [
-                names,     // names: vector<String>
-                urls       // links: vector<String>
-              ],
-            },
-          });
-        }
-      }
+      // create() updates an existing profile by replacing bio and the full LinkTree in one transaction
+      await signAndSubmitTransaction({
+        data: {
+          function: `${CONTRACT_ADDRESS}::profile::create`,
+          typeArguments: [],
+          functionArguments: [
+            nameToSave,           // name: String
+            bio,                  // bio: String
+            avatar,               // avatar_url: Option<String>
+            undefined,            // avatar_nft: Option<Object<Token>> - always empty for now
+            names,                // names: vector<String>
+            urls,                 // links: vector<String>
+          ],
+        },
+      });
 
       console.log('Profile saved successfully');
     } catch (error) {
@@ -177,6 +181,40 @@ export function ProfileEditor({ ansName, profile, onViewProfile, loading = false
           />
         </div>
       </header>
+
+      {/* Primary Socials */}
+      <section className="space-y-3 mb-8 w-full max-w-[500px] mx-auto">
+        <h2 className="text-white text-center text-[14px] sm:text-[16px] font-semibold">
+          Primary socials
+        </h2>
+        <div className="space-y-3">
+          {(Object.keys(SUPPORTED_PRIMARY_SOCIALS) as PrimarySocialPlatform[]).map((platform) => {
+            const config = SUPPORTED_PRIMARY_SOCIALS[platform];
+            return (
+              <div key={platform} className="flex gap-2 items-center">
+                <span
+                  className="w-[52px] h-[52px] bg-white/90 rounded-[14px] shadow-md flex items-center justify-center text-black"
+                  aria-hidden="true"
+                >
+                  <PrimarySocialIcon platform={platform} />
+                </span>
+                <input
+                  type="text"
+                  value={primarySocials[platform] ?? ''}
+                  onChange={(e) => setPrimarySocials({ ...primarySocials, [platform]: e.target.value })}
+                  placeholder={config.placeholder}
+                  aria-label={config.name}
+                  className="flex-1 px-4 py-[14px] sm:py-4 text-[14px] sm:text-[16px]
+                           text-center bg-white/90 focus:bg-white
+                           text-[#000000] rounded-[14px] transition-all
+                           duration-200 backdrop-blur-sm shadow-md
+                           focus:outline-none"
+                />
+              </div>
+            );
+          })}
+        </div>
+      </section>
 
       {/* Links Section */}
       <section className="space-y-3 mb-8 w-full max-w-[500px] mx-auto">
@@ -279,4 +317,4 @@ export function ProfileEditor({ ansName, profile, onViewProfile, loading = false
       </section>
     </div>
   );
-} 
+}

--- a/typescript/src/components/PublicProfile.tsx
+++ b/typescript/src/components/PublicProfile.tsx
@@ -11,6 +11,13 @@ import { TwitterIcon, GithubIcon, FacebookIcon, InstagramIcon, LinkedinIcon } fr
 import { DiscordLogoIcon, PaperPlaneIcon, ExternalLinkIcon, Share1Icon, CopyIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { formatAnsHandle, getDisplayName, shouldShowAnsHandle } from "@/lib/displayName.ts";
+import { PrimarySocialIcon } from "./PrimarySocialIcon";
+import {
+  SUPPORTED_PRIMARY_SOCIALS,
+  isSafePrimarySocialUrl,
+  isSupportedPrimarySocial,
+  splitProfileLinks,
+} from "@/lib/primarySocials.ts";
 
 interface PublicProfileProps {
   profile: Profile;
@@ -27,6 +34,10 @@ export default function PublicProfile({ profile }: PublicProfileProps) {
   
   // Check if the current user is the profile owner
   const isOwner = account?.address?.toString() === profile.owner;
+  const { regularLinks, primarySocials: parsedSocials } = splitProfileLinks(profile.links);
+  const primarySocials = Object.entries({ ...parsedSocials, ...profile.primarySocials }).filter(([platform, url]) =>
+    isSafePrimarySocialUrl(platform, url),
+  );
 
   const handleEdit = () => {
     router.push('/');
@@ -208,6 +219,26 @@ export default function PublicProfile({ profile }: PublicProfileProps) {
               {showAnsHandle && (
                 <p className="text-[13px] sm:text-[14px] text-white/60 mt-1">{ansHandle}</p>
               )}
+              {primarySocials.length > 0 && (
+                <div className="flex items-center justify-center gap-3 mt-3">
+                  {primarySocials.map(([platform, url]) => (
+                    <Link
+                      key={platform}
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={
+                        isSupportedPrimarySocial(platform)
+                          ? SUPPORTED_PRIMARY_SOCIALS[platform].name
+                          : platform
+                      }
+                      className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-white/90 hover:bg-white text-black shadow-md transition-all hover:scale-105"
+                    >
+                      <PrimarySocialIcon platform={platform} />
+                    </Link>
+                  ))}
+                </div>
+              )}
               <div className="flex items-center justify-center gap-4 mt-3 mb-4">
                 <Tooltip.Provider>
                   <Tooltip.Root>
@@ -266,7 +297,7 @@ export default function PublicProfile({ profile }: PublicProfileProps) {
 
           {/* Links Section */}
           <section className="space-y-3 mb-8 w-full max-w-[500px] mx-auto">
-            {profile.links.map((link) => (
+            {regularLinks.map((link) => (
               <div key={link.id} className="relative group flex items-center gap-2">
                 <Link href={link.url} target="_blank" rel="noopener noreferrer" className="block w-full">
                   <div

--- a/typescript/src/constants.ts
+++ b/typescript/src/constants.ts
@@ -10,3 +10,5 @@ export const client = new Aptos(
     clientConfig: { API_KEY: APTOS_API_KEY },
   }),
 );
+
+export { PRIMARY_SOCIAL_PREFIX, SUPPORTED_PRIMARY_SOCIALS } from "./lib/primarySocials.ts";

--- a/typescript/src/lib/primarySocials.test.ts
+++ b/typescript/src/lib/primarySocials.test.ts
@@ -38,6 +38,25 @@ test("toPrimarySocialUrl builds a platform URL and strips a leading @", () => {
 
 test("toPrimarySocialUrl keeps an already-absolute URL", () => {
   assert.equal(toPrimarySocialUrl("x", "https://x.com/aptoslabs"), "https://x.com/aptoslabs");
+  assert.equal(toPrimarySocialUrl("x", "https://twitter.com/aptoslabs"), "https://twitter.com/aptoslabs");
+});
+
+test("toPrimarySocialUrl rejects absolute URLs on the wrong host", () => {
+  assert.equal(toPrimarySocialUrl("x", "https://evil.com/aptoslabs"), null);
+  assert.equal(toPrimarySocialUrl("github", "https://x.com/aptoslabs"), null);
+});
+
+test("buildPrimarySocialUpdates skips unsafe absolute URLs", () => {
+  const result = buildPrimarySocialUpdates({ x: "https://evil.com/aptos" });
+  assert.deepEqual(result.toUpsert, { names: [], urls: [] });
+});
+
+test("splitProfileLinks ignores a key that only contains the prefix in the middle", () => {
+  const { regularLinks, primarySocials } = splitProfileLinks([
+    { id: "my__primary:site", title: "my__primary:site", url: "https://example.com" },
+  ]);
+  assert.deepEqual(regularLinks, [{ id: "my__primary:site", title: "my__primary:site", url: "https://example.com" }]);
+  assert.deepEqual(primarySocials, {});
 });
 
 test("extractPrimarySocialHandle recovers handles from stored URLs", () => {

--- a/typescript/src/lib/primarySocials.test.ts
+++ b/typescript/src/lib/primarySocials.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  PRIMARY_SOCIAL_PREFIX,
+  buildPrimarySocialUpdates,
+  extractPrimarySocialHandle,
+  splitProfileLinks,
+  toPrimarySocialUrl,
+} from "./primarySocials.ts";
+
+test("splitProfileLinks separates prefixed socials from regular links", () => {
+  const { regularLinks, primarySocials } = splitProfileLinks([
+    { id: "Website", title: "Website", url: "https://example.com" },
+    { id: `${PRIMARY_SOCIAL_PREFIX}x`, title: `${PRIMARY_SOCIAL_PREFIX}x`, url: "https://x.com/aptoslabs" },
+    {
+      id: `${PRIMARY_SOCIAL_PREFIX}github`,
+      title: `${PRIMARY_SOCIAL_PREFIX}github`,
+      url: "https://github.com/aptos-labs",
+    },
+  ]);
+
+  assert.deepEqual(regularLinks, [{ id: "Website", title: "Website", url: "https://example.com" }]);
+  assert.deepEqual(primarySocials, {
+    x: "https://x.com/aptoslabs",
+    github: "https://github.com/aptos-labs",
+  });
+});
+
+test("splitProfileLinks returns empty maps for empty input", () => {
+  assert.deepEqual(splitProfileLinks([]), { regularLinks: [], primarySocials: {} });
+});
+
+test("toPrimarySocialUrl builds a platform URL and strips a leading @", () => {
+  assert.equal(toPrimarySocialUrl("x", "@aptoslabs"), "https://x.com/aptoslabs");
+  assert.equal(toPrimarySocialUrl("telegram", "aptos"), "https://t.me/aptos");
+  assert.equal(toPrimarySocialUrl("github", "aptos-labs"), "https://github.com/aptos-labs");
+});
+
+test("toPrimarySocialUrl keeps an already-absolute URL", () => {
+  assert.equal(toPrimarySocialUrl("x", "https://x.com/aptoslabs"), "https://x.com/aptoslabs");
+});
+
+test("extractPrimarySocialHandle recovers handles from stored URLs", () => {
+  assert.equal(extractPrimarySocialHandle("x", "https://x.com/aptoslabs"), "aptoslabs");
+  assert.equal(extractPrimarySocialHandle("x", "https://twitter.com/aptoslabs"), "aptoslabs");
+  assert.equal(extractPrimarySocialHandle("telegram", "https://t.me/aptos"), "aptos");
+  assert.equal(extractPrimarySocialHandle("github", "aptos-labs"), "aptos-labs");
+});
+
+test("buildPrimarySocialUpdates upserts filled handles and removes cleared ones", () => {
+  const result = buildPrimarySocialUpdates(
+    { x: "@aptoslabs", telegram: "", github: "aptos-labs" },
+    { x: "https://x.com/old", telegram: "https://t.me/old" },
+  );
+
+  assert.deepEqual(result.toUpsert, {
+    names: [`${PRIMARY_SOCIAL_PREFIX}x`, `${PRIMARY_SOCIAL_PREFIX}github`],
+    urls: ["https://x.com/aptoslabs", "https://github.com/aptos-labs"],
+  });
+  assert.deepEqual(result.toRemove, [`${PRIMARY_SOCIAL_PREFIX}telegram`]);
+});

--- a/typescript/src/lib/primarySocials.ts
+++ b/typescript/src/lib/primarySocials.ts
@@ -1,0 +1,124 @@
+import type { ProfileLink } from "../types/index.ts";
+
+export const PRIMARY_SOCIAL_PREFIX = "__primary:";
+
+export const SUPPORTED_PRIMARY_SOCIALS = {
+  x: {
+    name: "X (Twitter)",
+    placeholder: "@username",
+    baseUrl: "https://x.com/",
+  },
+  telegram: {
+    name: "Telegram",
+    placeholder: "@username",
+    baseUrl: "https://t.me/",
+  },
+  github: {
+    name: "GitHub",
+    placeholder: "username",
+    baseUrl: "https://github.com/",
+  },
+} as const;
+
+export type PrimarySocialPlatform = keyof typeof SUPPORTED_PRIMARY_SOCIALS;
+
+export type PrimarySocials = { [platform: string]: string };
+
+export function isSupportedPrimarySocial(platform: string): platform is PrimarySocialPlatform {
+  return platform in SUPPORTED_PRIMARY_SOCIALS;
+}
+
+export function isPrimarySocialKey(key: string): boolean {
+  return key.startsWith(PRIMARY_SOCIAL_PREFIX);
+}
+
+export function splitProfileLinks(links: ProfileLink[]): {
+  regularLinks: ProfileLink[];
+  primarySocials: PrimarySocials;
+} {
+  const regularLinks: ProfileLink[] = [];
+  const primarySocials: PrimarySocials = {};
+
+  for (const link of links) {
+    const key = link.id || link.title;
+    if (isPrimarySocialKey(key)) {
+      const platform = key.slice(PRIMARY_SOCIAL_PREFIX.length);
+      if (platform) {
+        primarySocials[platform] = link.url;
+      }
+    } else {
+      regularLinks.push(link);
+    }
+  }
+
+  return { regularLinks, primarySocials };
+}
+
+export function toPrimarySocialUrl(platform: string, handleOrUrl: string): string {
+  const trimmed = handleOrUrl.trim();
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  const handle = trimmed.replace(/^@+/, "");
+  if (isSupportedPrimarySocial(platform)) {
+    return `${SUPPORTED_PRIMARY_SOCIALS[platform].baseUrl}${handle}`;
+  }
+
+  return trimmed;
+}
+
+export function extractPrimarySocialHandle(platform: string, value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const prefixes: Array<string | undefined> = [
+    isSupportedPrimarySocial(platform) ? SUPPORTED_PRIMARY_SOCIALS[platform].baseUrl : undefined,
+  ];
+  if (platform === "x") {
+    prefixes.push("https://twitter.com/", "https://www.twitter.com/", "https://www.x.com/");
+  }
+  if (platform === "telegram") {
+    prefixes.push("https://telegram.me/", "https://www.t.me/");
+  }
+  if (platform === "github") {
+    prefixes.push("https://www.github.com/");
+  }
+
+  for (const prefix of prefixes) {
+    if (prefix && trimmed.startsWith(prefix)) {
+      return trimmed.slice(prefix.length).replace(/^@+/, "").replace(/\/+$/, "");
+    }
+  }
+
+  return trimmed.replace(/^@+/, "");
+}
+
+export function buildPrimarySocialUpdates(
+  handles: PrimarySocials,
+  previousUrls: PrimarySocials = {},
+): { toUpsert: { names: string[]; urls: string[] }; toRemove: string[] } {
+  const names: string[] = [];
+  const urls: string[] = [];
+  const toRemove: string[] = [];
+  const platforms = new Set([
+    ...Object.keys(SUPPORTED_PRIMARY_SOCIALS),
+    ...Object.keys(handles),
+    ...Object.keys(previousUrls),
+  ]);
+
+  for (const platform of platforms) {
+    const handle = (handles[platform] ?? "").trim();
+    const key = `${PRIMARY_SOCIAL_PREFIX}${platform}`;
+    if (handle) {
+      names.push(key);
+      urls.push(toPrimarySocialUrl(platform, handle));
+    } else if (previousUrls[platform]) {
+      toRemove.push(key);
+    }
+  }
+
+  return { toUpsert: { names, urls }, toRemove };
+}

--- a/typescript/src/lib/primarySocials.ts
+++ b/typescript/src/lib/primarySocials.ts
@@ -24,8 +24,14 @@ export type PrimarySocialPlatform = keyof typeof SUPPORTED_PRIMARY_SOCIALS;
 
 export type PrimarySocials = { [platform: string]: string };
 
+const PLATFORM_HOSTS: Record<PrimarySocialPlatform, readonly string[]> = {
+  x: ["x.com", "twitter.com"],
+  telegram: ["t.me", "telegram.me"],
+  github: ["github.com"],
+};
+
 export function isSupportedPrimarySocial(platform: string): platform is PrimarySocialPlatform {
-  return platform in SUPPORTED_PRIMARY_SOCIALS;
+  return Object.prototype.hasOwnProperty.call(SUPPORTED_PRIMARY_SOCIALS, platform);
 }
 
 export function isPrimarySocialKey(key: string): boolean {
@@ -42,7 +48,7 @@ export function splitProfileLinks(links: ProfileLink[]): {
   for (const link of links) {
     const key = link.id || link.title;
     if (isPrimarySocialKey(key)) {
-      const platform = key.slice(PRIMARY_SOCIAL_PREFIX.length);
+      const platform = key.slice(PRIMARY_SOCIAL_PREFIX.length).toLowerCase();
       if (platform) {
         primarySocials[platform] = link.url;
       }
@@ -54,18 +60,35 @@ export function splitProfileLinks(links: ProfileLink[]): {
   return { regularLinks, primarySocials };
 }
 
-export function toPrimarySocialUrl(platform: string, handleOrUrl: string): string {
+export function isSafePrimarySocialUrl(platform: string, url: string): boolean {
+  if (!/^https:\/\//i.test(url) || !isSupportedPrimarySocial(platform)) {
+    return false;
+  }
+  try {
+    const host = new URL(url).hostname.replace(/^www\./i, "").toLowerCase();
+    return PLATFORM_HOSTS[platform].some((allowed) => host === allowed || host.endsWith(`.${allowed}`));
+  } catch {
+    return false;
+  }
+}
+
+export function toPrimarySocialUrl(platform: string, handleOrUrl: string): string | null {
   const trimmed = handleOrUrl.trim();
+  if (!trimmed) {
+    return null;
+  }
+
   if (/^https?:\/\//i.test(trimmed)) {
-    return trimmed;
+    const httpsUrl = trimmed.replace(/^http:\/\//i, "https://");
+    return isSafePrimarySocialUrl(platform, httpsUrl) ? httpsUrl : null;
   }
 
   const handle = trimmed.replace(/^@+/, "");
-  if (isSupportedPrimarySocial(platform)) {
-    return `${SUPPORTED_PRIMARY_SOCIALS[platform].baseUrl}${handle}`;
+  if (!handle || /[/?#]/.test(handle) || !isSupportedPrimarySocial(platform)) {
+    return null;
   }
 
-  return trimmed;
+  return `${SUPPORTED_PRIMARY_SOCIALS[platform].baseUrl}${handle}`;
 }
 
 export function extractPrimarySocialHandle(platform: string, value: string): string {
@@ -74,22 +97,18 @@ export function extractPrimarySocialHandle(platform: string, value: string): str
     return "";
   }
 
-  const prefixes: Array<string | undefined> = [
-    isSupportedPrimarySocial(platform) ? SUPPORTED_PRIMARY_SOCIALS[platform].baseUrl : undefined,
-  ];
-  if (platform === "x") {
-    prefixes.push("https://twitter.com/", "https://www.twitter.com/", "https://www.x.com/");
-  }
-  if (platform === "telegram") {
-    prefixes.push("https://telegram.me/", "https://www.t.me/");
-  }
-  if (platform === "github") {
-    prefixes.push("https://www.github.com/");
-  }
-
-  for (const prefix of prefixes) {
-    if (prefix && trimmed.startsWith(prefix)) {
-      return trimmed.slice(prefix.length).replace(/^@+/, "").replace(/\/+$/, "");
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const parsed = new URL(trimmed);
+      const host = parsed.hostname.replace(/^www\./i, "").toLowerCase();
+      if (
+        isSupportedPrimarySocial(platform) &&
+        PLATFORM_HOSTS[platform].some((allowed) => host === allowed || host.endsWith(`.${allowed}`))
+      ) {
+        return parsed.pathname.replace(/^\/+/, "").replace(/\/+$/, "");
+      }
+    } catch {
+      return trimmed.replace(/^@+/, "");
     }
   }
 
@@ -112,9 +131,10 @@ export function buildPrimarySocialUpdates(
   for (const platform of platforms) {
     const handle = (handles[platform] ?? "").trim();
     const key = `${PRIMARY_SOCIAL_PREFIX}${platform}`;
-    if (handle) {
+    const url = handle ? toPrimarySocialUrl(platform, handle) : null;
+    if (url) {
       names.push(key);
-      urls.push(toPrimarySocialUrl(platform, handle));
+      urls.push(url);
     } else if (previousUrls[platform]) {
       toRemove.push(key);
     }

--- a/typescript/src/types/index.ts
+++ b/typescript/src/types/index.ts
@@ -12,4 +12,5 @@ export interface Profile {
   description: string;
   title: string;
   links: ProfileLink[];
+  primarySocials: { [platform: string]: string };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #51.

Adds prefix-based primary socials (X, Telegram, GitHub) using the existing LinkTree, so current profiles keep working and no migration is required.

Rebased onto `main` (includes display-name #61 and dependency bumps). Combined with the display-name UI: custom title, ANS handle subtitle, then the primary-social icon row.

## Contract
- `get_primary_socials(owner)` view filters LinkTree keys that start with `__primary:`
- Optional `set_primary_social` / `remove_primary_social` wrappers around `add_links` / `remove_links` (`url` is stored as-is; pass a full URL)
- Move unit tests cover empty profiles, mixed links, and set/remove

`SimpleMap` on mainnet has no `for_each_ref`, so the view iterates `keys()` instead of the snippet in the proposal.

## Frontend
- Editor fields for X, Telegram, and GitHub above the regular links list
- Public profiles show those accounts as an icon row (below the display name / ANS handle) and hide `__primary:` keys from the generic list
- Saves through existing `create()` (create-or-replace bio + full LinkTree in one transaction), keeping the custom display name in `Bio.name`
- Off-host URLs are rejected so a primary-social icon cannot point at an untrusted domain
- Parsing helpers have Node unit tests (`pnpm test`)

## Notes
- Indexer is unchanged; primary socials live in the same LinkTree resource
- A contract upgrade is still needed before `get_primary_socials` / the convenience entry functions exist on-chain; the UI does not call those yet
- No GitHub review threads on this PR; previous hardening review (host allowlist, single `create()`, Move `url` argument, drop `loaded` from the home fetch) is preserved after rebase

## Verification
- `aptos move test` — 3/3 passed
- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` (21: display-name + primary socials), `pnpm build` — passed
- Vercel on the rebased head: Ready
- GitHub `mergeable_state`: clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e798ee8c-d159-48a1-b2ff-ab8098b56c31?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e798ee8c-d159-48a1-b2ff-ab8098b56c31&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

